### PR TITLE
1. Maak de namen van indexen configureerbaar.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ index the DIPs created by [Archivematica](https://www.archivematica.org) and to 
 
 1. [Components](#components)
 1. [Services](#services)
-    1. [Default services](#default-services)
+    1. [Default services](#default-service)
     1. [Workers](#workers)
     1. [Cron jobs](#cron-jobs)
     1. [Standalones](#standalones)
@@ -385,6 +385,7 @@ The environment variables used to configure the application:
 - `IIIF_SERVER_ELASTICSEARCH_URL`: URL of the ElasticSearch indexer
 - `IIIF_SERVER_ELASTICSEARCH_USER`: Username of the ElasticSearch indexer if authentication is enabled
 - `IIIF_SERVER_ELASTICSEARCH_PASSWORD`: Password of the ElasticSearch indexer if authentication is enabled
+- `IIIF_SERVER_ELASTICSEARCH_INDEX_PREFIX`: The text placed in front of the indices 'items' and 'texts'. 
 - `IIIF_SERVER_REDIS_VOLATILE_DISABLED`: Turn Redis volatile server on/off (Sets up caching)
 - `IIIF_SERVER_REDIS_VOLATILE_HOST`: Host of the Redis caching server
 - `IIIF_SERVER_REDIS_VOLATILE_PORT`: Port of the Redis caching server

--- a/src/admin/api_index.ts
+++ b/src/admin/api_index.ts
@@ -8,7 +8,7 @@ export default async function indexCollection(collection: { id?: string; name?: 
     if (!('id' in collection) || !collection.id)
         throw new HttpError(400, 'ID missing');
 
-    if (!(config.elasticSearchIndexItems in collection) || !collection.items)
+    if (!('items' in collection) || !collection.items)
         throw new HttpError(400, 'Items missing');
 
     await deleteItems(collection.id);

--- a/src/admin/api_index.ts
+++ b/src/admin/api_index.ts
@@ -2,12 +2,13 @@ import HttpError from '../lib/HttpError';
 import {evictCache} from '../lib/Cache';
 import {Item} from '../lib/ItemInterfaces';
 import {createItem, indexItems, deleteItems} from '../lib/Item';
+import config from "../lib/Config";
 
 export default async function indexCollection(collection: { id?: string; name?: string, items?: Item[] }): Promise<void> {
     if (!('id' in collection) || !collection.id)
         throw new HttpError(400, 'ID missing');
 
-    if (!('items' in collection) || !collection.items)
+    if (!(config.elasticSearchIndexItems in collection) || !collection.items)
         throw new HttpError(400, 'Items missing');
 
     await deleteItems(collection.id);

--- a/src/lib/Config.ts
+++ b/src/lib/Config.ts
@@ -16,6 +16,8 @@ export interface Config {
     audioRelativePath?: string;
     elasticSearchUser?: string;
     elasticSearchPassword?: string;
+    elasticSearchIndexItems: string;
+    elasticSearchIndexTexts: string;
     ipAddressHeader?: string;
     imageServerUrl: string;
     imageServerName: 'loris' | 'sharp';
@@ -230,6 +232,18 @@ const config: Config = {
         if (!process.env.IIIF_SERVER_ELASTICSEARCH_URL || (process.env.IIIF_SERVER_ELASTICSEARCH_URL === 'null'))
             throw new Error('The ElasticSearch URL is not defined');
         return process.env.IIIF_SERVER_ELASTICSEARCH_URL;
+    })(),
+
+    elasticSearchIndexItems: (_ => {
+        return (!process.env.IIIF_SERVER_ELASTICSEARCH_INDEX_PREFIX || (process.env.IIIF_SERVER_ELASTICSEARCH_INDEX_PREFIX === 'null'))
+            ? 'items'
+            : process.env.IIIF_SERVER_ELASTICSEARCH_INDEX_PREFIX.concat('_', 'items');
+    })(),
+
+    elasticSearchIndexTexts: (_ => {
+        return (!process.env.IIIF_SERVER_ELASTICSEARCH_INDEX_PREFIX || (process.env.IIIF_SERVER_ELASTICSEARCH_INDEX_PREFIX === 'null'))
+            ? 'texts'
+            : process.env.IIIF_SERVER_ELASTICSEARCH_INDEX_PREFIX.concat('_', 'texts');
     })(),
 
     redisVolatile: (_ => {

--- a/src/lib/ElasticSearch.ts
+++ b/src/lib/ElasticSearch.ts
@@ -31,10 +31,10 @@ export function setElasticSearchClient(client: Client): void {
     try {
         await client.ping();
 
-        const itemsExists = await client.indices.exists({index: 'items'});
+        const itemsExists = await client.indices.exists({index: config.elasticSearchIndexItems});
         if (!itemsExists.body) {
             await client.indices.create({
-                index: 'items',
+                index: config.elasticSearchIndexItems,
                 body: {
                     mappings: {
                         properties: {
@@ -140,13 +140,13 @@ export function setElasticSearchClient(client: Client): void {
                 }
             });
 
-            logger.info('Created the index \'items\' with a mapping');
+            logger.info('Created the index '.concat(config.elasticSearchIndexItems, ' with a mapping'));
         }
 
-        const textsExists = await client.indices.exists({index: 'texts'});
+        const textsExists = await client.indices.exists({index: config.elasticSearchIndexTexts});
         if (!textsExists.body) {
             await client.indices.create({
-                index: 'texts',
+                index: config.elasticSearchIndexTexts,
                 body: {
                     settings: {
                         analysis: {
@@ -213,7 +213,7 @@ export function setElasticSearchClient(client: Client): void {
                 }
             });
 
-            logger.info('Created the index \'texts\' with a mapping');
+            logger.info('Created the index '.concat(config.elasticSearchIndexTexts, ' with a mapping'));
         }
     }
     catch (e) {

--- a/src/lib/ElasticSearch.ts
+++ b/src/lib/ElasticSearch.ts
@@ -140,7 +140,7 @@ export function setElasticSearchClient(client: Client): void {
                 }
             });
 
-            logger.info('Created the index '.concat(config.elasticSearchIndexItems, ' with a mapping'));
+            logger.info(`Created the index ${config.elasticSearchIndexItems} with a mapping`);
         }
 
         const textsExists = await client.indices.exists({index: config.elasticSearchIndexTexts});
@@ -213,7 +213,7 @@ export function setElasticSearchClient(client: Client): void {
                 }
             });
 
-            logger.info('Created the index '.concat(config.elasticSearchIndexTexts, ' with a mapping'));
+            logger.info(`Created the index ${config.elasticSearchIndexTexts} with a mapping`);
         }
     }
     catch (e) {

--- a/src/lib/Item.ts
+++ b/src/lib/Item.ts
@@ -42,7 +42,7 @@ export async function indexItems(items: Item[]): Promise<void> {
             const body = items
                 .splice(0, 100)
                 .map(item => [
-                    {index: {_index: 'items', _id: item.id}},
+                    {index: {_index: config.elasticSearchIndexItems, _id: item.id}},
                     item
                 ]);
 
@@ -66,7 +66,7 @@ export async function updateItems(items: MinimalItem[]): Promise<void> {
             const body = uniqueItems
                 .splice(0, 100)
                 .map(item => [
-                    {update: {_index: 'items', _id: item.id}},
+                    {update: {_index: config.elasticSearchIndexItems, _id: item.id}},
                     {doc: item, upsert: createItem(item)}
                 ]);
 
@@ -82,7 +82,7 @@ export async function updateItems(items: MinimalItem[]): Promise<void> {
 
 export async function deleteItems(collectionId: string): Promise<void> {
     await getClient().deleteByQuery({
-        index: 'items',
+        index: config.elasticSearchIndexItems,
         q: `collection_id:"${collectionId}"`,
         body: {}
     });
@@ -91,7 +91,7 @@ export async function deleteItems(collectionId: string): Promise<void> {
 export async function getItem(id: string): Promise<Item | null> {
     try {
         logger.debug(`Obtain item from ElasticSearch with id ${id}`);
-        const response = await getClient().get({index: 'items', id: id});
+        const response = await getClient().get({index: config.elasticSearchIndexItems, id: id});
         return response.body._source;
     }
     catch (err) {
@@ -167,7 +167,7 @@ export function getAllRootItems(): AsyncIterable<Item> {
 
 function getItems(q: string): AsyncIterable<Item> {
     logger.debug(`Obtain items from ElasticSearch with query "${q}"`);
-    return getClient().helpers.scrollDocuments<Item>({index: 'items', sort: 'label:asc', q});
+    return getClient().helpers.scrollDocuments<Item>({index: config.elasticSearchIndexItems, sort: 'label:asc', q});
 }
 
 export function getFullPath(item: Item, type: 'access' | 'original' | null = null): string {

--- a/src/lib/Text.ts
+++ b/src/lib/Text.ts
@@ -41,7 +41,7 @@ export async function indexTexts(textItems: Text[]): Promise<void> {
             const body = textItems
                 .splice(0, 100)
                 .map(item => [
-                    {index: {_index: 'texts', _id: item.id}},
+                    {index: {_index: config.elasticSearchIndexTexts, _id: item.id}},
                     item
                 ]);
 
@@ -58,7 +58,7 @@ export async function indexTexts(textItems: Text[]): Promise<void> {
 
 export async function deleteTexts(collectionId: string): Promise<void> {
     await getClient().deleteByQuery({
-        index: 'texts',
+        index: config.elasticSearchIndexTexts,
         q: `collection_id:${collectionId}`,
         body: {}
     });
@@ -66,7 +66,7 @@ export async function deleteTexts(collectionId: string): Promise<void> {
 
 export async function getText(id: string): Promise<Text | null> {
     try {
-        const response = await getClient().get({index: 'texts', id: id});
+        const response = await getClient().get({index: config.elasticSearchIndexTexts, id: id});
         return response.body._source;
     }
     catch (err) {
@@ -87,7 +87,7 @@ export function getTextsForCollectionId(collectionId: string, type?: string,
 
 function getTexts(q: string): AsyncIterable<Text> {
     logger.debug(`Obtain texts from ElasticSearch with query "${q}"`);
-    return getClient().helpers.scrollDocuments<Text>({index: 'texts', q});
+    return getClient().helpers.scrollDocuments<Text>({index: config.elasticSearchIndexTexts, q});
 }
 
 export async function readAlto(uri: string): Promise<OcrWord[]> {

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -73,7 +73,7 @@ async function search(query: string, filters: { [field: string]: string | undefi
     query = isPhraseMatch ? query.substring(1, query.length - 1) : query;
 
     const response: ApiResponse<SearchResponse> = await getClient().search({
-        index: 'texts',
+        index: config.elasticSearchIndexTexts,
         size: config.maxSearchResults,
         body: {
             query: {
@@ -112,7 +112,7 @@ async function autocomplete(query: string, filters: { [field: string]: string | 
     query = query.trim();
 
     const response: ApiResponse<AutocompleteResponse> = await getClient().search({
-        index: 'texts',
+        index: config.elasticSearchIndexTexts,
         body: {
             _source: false,
             query: {

--- a/src/service/iish/util/EAD.ts
+++ b/src/service/iish/util/EAD.ts
@@ -47,7 +47,7 @@ export function getMetadata(collectionId: string, ead: Document): EADMetadata[] 
 export function getAccess(collectionId: string, ead: Document): string {
     let restriction: string | null = null;
     const accessRestrict = ead
-        .get<Element>('//ead:ead/ead:archdesc/ead:descgrp[@type="access_and_use"]/ead:accessrestrict', ns);
+        .get<Element>('//ead:ead/ead:archdesc/ead:descgrp[@type="access_and_use"]/ead:accessrestrict|//ead:ead/ead:archdesc/ead:accessrestrict', ns);
     if (accessRestrict) {
         const accessValue = accessRestrict.get<Element>('./ead:p', ns);
         if (accessValue)
@@ -114,7 +114,7 @@ function extractMetadataFromLevel(level: Element | null, parentMetadata: EADMeta
 
 function extractFormats(ead: Element, metadata: EADMetadata, parentMetadata: EADMetadata | null): void {
     const formatElems = ead.find<Element>('./ead:descgrp[@type="content_and_structure"]/' +
-        'ead:controlaccess/ead:controlaccess/ead:genreform', ns);
+        'ead:controlaccess/ead:controlaccess/ead:genreform|ead:controlaccess/ead:genreform', ns);
 
     const formats = formatElems.map(formatElem => {
         const format = formatElem.text().toLowerCase();
@@ -168,7 +168,7 @@ function extractOrder(ead: Element, metadata: EADMetadata): void {
 }
 
 function extractContent(ead: Element, metadata: EADMetadata): void {
-    const content = ead.find<Element>('./ead:descgrp[@type="content_and_structure"]/ead:scopecontent/ead:p', ns);
+    const content = ead.find<Element>('./ead:descgrp[@type="content_and_structure"]/ead:scopecontent/ead:p|./ead:scopecontent/ead:p', ns);
 
     if (content.length > 0)
         metadata.content = content

--- a/src/service/process_update.ts
+++ b/src/service/process_update.ts
@@ -2,9 +2,10 @@ import {runTask} from '../lib/Task';
 import {Item} from '../lib/ItemInterfaces';
 import getClient from '../lib/ElasticSearch';
 import {ProcessUpdateParams, MetadataParams, DerivativeParams} from '../lib/Service';
+import config from "../lib/Config";
 
 export default async function processUpdate({type, query}: ProcessUpdateParams): Promise<void> {
-    const scrollItems = getClient().helpers.scrollDocuments<Item>({index: 'items', q: query});
+    const scrollItems = getClient().helpers.scrollDocuments<Item>({index: config.elasticSearchIndexItems, q: query});
     for await (const item of scrollItems)
         runTask<MetadataParams | DerivativeParams>(type, {collectionId: item.collection_id});
 }


### PR DESCRIPTION
In deze commit:
1. Default voor indicis zijn items en t'exts. Met een configuratie kan daar een prefix tegen aan. Dat is voor het draaien van meerdere IIIF servers bij 1 elastic search instantie.
2. Pas EAD xpath paden aan, zodat deze twee EAD dialecten bewandelen. Dit voor IISH stap naar Archivesspace
3. Spelfoutje in readme default services