### PR TITLE
Fix caching of annopages

### DIFF
--- a/src/presentation/router.ts
+++ b/src/presentation/router.ts
@@ -72,7 +72,7 @@ router.get('/:id/annopage/:annoPageId', async ctx => {
 
     setContent(
         ctx,
-        await cache('annopage', item.collection_id, item.id,
+        await cache('annopage', item.collection_id, text.id,
             async () => getAnnotationPage(item, text))
     );
 


### PR DESCRIPTION
This PR fixes a bug regarding the caching of annopages. 

Previously, for a given collection, the same annopage would always be returned. 

