### PR TITLE
Enable search for texts based on line-level ALTO annotations

### DIFF
--- a/src/builder/Digitized.ts
+++ b/src/builder/Digitized.ts
@@ -115,7 +115,13 @@ export async function getAnnotationPage(item: RootItem, text: Text): Promise<Ann
                 const resource = Resource.createTextResource(word.content, text.language);
                 const annotation = new Annotation(annoUri(item.id, childItem.id, word.idx), resource, 'supplementing');
 
-                annotation.setTextGranularity('word');
+                if (word.content.split(/\s+/).filter(w => w.length > 0).length > 1){
+
+                    annotation.setTextGranularity('line');
+                }else{
+                    annotation.setTextGranularity('word');
+                }
+
                 annotation.setCanvas(canvas, {x: word.x, y: word.y, w: word.width, h: word.height});
 
                 annotations.push(annotation);

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -138,10 +138,21 @@ function mapMatches(text: Text, hl: string, matchExact: string | null): SearchRe
         .split(/[\t\r\n\s]+/)
         .filter(token => token.length > 0);
 
+    let id = 0;
+    const extractedWords: TextWord[] = [];
+    for (const word of words) {
+        const splitAttempt = word.content.split(/\s+/).filter(w => w.length > 0);
+        if (splitAttempt.length > 1) {
+            extractedWords.push(...splitAttempt.map(w => <TextWord>{ ...word, idx: id++, content: w, isHyphenated: false }));
+        } else {
+            extractedWords.push(<TextWord>{ ...word, idx: id++ });
+        }
+    }
+
     let tokenIdx = 0, wordIdx = 0, curMatch: SearchResultMatch | null = null;
     while (tokenIdx < tokens.length) {
         const token = tokens[tokenIdx];
-        const word = wordIdx < words.length ? words[wordIdx] : null;
+        const word = wordIdx < extractedWords.length ? extractedWords[wordIdx] : null;
 
         if (token.startsWith(PRE_TAG)) {
             if (curMatch == null)
@@ -159,7 +170,7 @@ function mapMatches(text: Text, hl: string, matchExact: string | null): SearchRe
 
         if (word?.isHyphenated) {
             wordIdx++;
-            curMatch?.words.push(words[wordIdx]);
+            curMatch?.words.push(extractedWords[wordIdx]);
         }
 
         if (curMatch && (!matchExact || matchExact === curMatch.match)) {


### PR DESCRIPTION
The current ALTO-based text indexing assumes that transcriptions are recorded at a word-level, e.g.: 

```xml
<TextLine ID="TextLine1" HEIGHT="37" WIDTH="218" HPOS="1557" VPOS="297">
  <String ID="String1" CONTENT="The" HEIGHT="4" WIDTH="47" HPOS="1557" VPOS="318"/>
  <SP ID="SP1" WIDTH="25" HPOS="1604" VPOS="297"/>
  <String ID="String2" CONTENT="first" HEIGHT="37" WIDTH="23" HPOS="1654" VPOS="297"/>
  <SP ID="SP2" WIDTH="49" HPOS="1677" VPOS="297"/>
  <String ID="String3" CONTENT="block." HEIGHT="3" WIDTH="49" HPOS="1726" VPOS="319"/>
</TextLine>
```

Depending on the OCR/HTR tool, this is not always the case, and transcriptions may instead be recorded at a line-level, e.g.: 

```xml
<TextLine ID="TextLine1" HEIGHT="37" WIDTH="218" HPOS="1557" VPOS="297">
  <String ID="String1" CONTENT="The first block" HEIGHT="37" WIDTH="218" HPOS="1557" VPOS="297"/>
</TextLine>
```

In the letter case, the search only populates the "hits" portion of the response, while "resources" (annotations) are left blank. Due to this, search result highlighting does not work in Mirador/UV. 

This PR introduces a quick work-around to enable search result highlighting for line-level annotations. Text lines are tokenised to create new `TextWords`, which retain the original line's coordinates and dimensions, allowing the rest of the search to function properly. 

Additionally, this PR sets the `textGranularity` for annotation pages to `line` if more than one work is present in a `TextWord` content. This is more of a cosmetic than functionally-required change. 