### PR TITLE
Adds env configuration for disabling fuzziness in search

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -532,6 +532,7 @@ The environment variables used to configure the application:
 - `IIIF_SERVER_ATTRIBUTION`: Attribution to add to the IIIF manifests
 - `IIIF_SERVER_BASE_URL`: The public base URL of the application
 - `IIIF_SERVER_VIEWER_URL`: The URL of the main IIIF viewer to use (the manifest URI will be added to this URL)
+- `IIIF_SERVER_SEARCH_MODE`: The search mode to use: `fuzzy` (default) for fuzzy matching or `phrase` for exact phrase matching
 - `IIIF_SERVER_HOT_FOLDER_PATH`: The path to the hot folder where new collections to be indexed are placed
 - `IIIF_SERVER_HOT_FOLDER_PATTERN`: The pattern of a file in the root of a new collection to trigger indexing
 - `IIIF_SERVER_DATA_ROOT_PATH`: The root path of the data storage

--- a/src/lib/Config.ts
+++ b/src/lib/Config.ts
@@ -34,6 +34,7 @@ export interface Config {
     imageTierSeparator: string;
     maxTasksPerWorker: number;
     maxSearchResults: number;
+    searchMode: 'fuzzy' | 'phrase';
     services: string[];
     secret: string;
     accessToken: string;
@@ -159,6 +160,12 @@ const config: Config = {
         const maxSearchResults = process.env.IIIF_SERVER_MAX_SEARCH_RESULTS
             ? parseInt(process.env.IIIF_SERVER_MAX_SEARCH_RESULTS) : 0;
         return (maxSearchResults > 0) ? maxSearchResults : 5000;
+    })(),
+
+    searchMode: (_ => {
+        const mode = process.env.IIIF_SERVER_SEARCH_MODE?.toLowerCase();
+        if (mode === 'phrase') return 'phrase' as const;
+        return 'fuzzy' as const;
     })(),
 
     services: (_ => {

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -55,11 +55,10 @@ async function search(query: string, filters: { [field: string]: string | undefi
         query: {
             bool: {
                 must: {
-                    [isPhraseMatch ? 'match_phrase' : 'match']: {
+                    [isPhraseMatch || config.searchMode === 'phrase' ? 'match_phrase' : 'match']: {
                         text: {
                             query,
-                            fuzziness: !isPhraseMatch ? 'AUTO' : undefined
-                        }
+                            fuzziness: !isPhraseMatch && config.searchMode === 'fuzzy' ? 'AUTO' : undefined
                     }
                 },
                 should: undefined,

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -59,6 +59,7 @@ async function search(query: string, filters: { [field: string]: string | undefi
                         text: {
                             query,
                             fuzziness: !isPhraseMatch && config.searchMode === 'fuzzy' ? 'AUTO' : undefined
+                        }
                     }
                 },
                 should: undefined,


### PR DESCRIPTION
Adds configuration environment variable `IIIF_SERVER_SEARCH_MODE`, which has two possible values:
* `fuzzy` - current behaviour, with fuzziness when making search queries to ElasticSearch.
* `phrase` - new behaviour without fuzziness.

Default is `fuzzy` (current behaviour).